### PR TITLE
qr image not showing fix on systems having raspap root other than ser…

### DIFF
--- a/templates/hostapd/security.php
+++ b/templates/hostapd/security.php
@@ -20,7 +20,7 @@
     </div>
     <div class="col-md-6">
       <figure class="figure">
-        <img src="/app/img/wifi-qr-code.php" class="figure-img img-fluid" alt="RaspAP Wifi QR code" style="width:100%;">
+        <img src="app/img/wifi-qr-code.php" class="figure-img img-fluid" alt="RaspAP Wifi QR code" style="width:100%;">
         <figcaption class="figure-caption"><?php echo _("Scan this QR code with your phone to connect to this RaspAP."); ?></figcaption>
       </figure>
     </div>


### PR DESCRIPTION
…ver root

when i installed raspap, i set my path /var/www/html/raspap instead of default /var/www/html. so i was facing error with qr code showing on security tab of hostapd page.

now i fixed it up....